### PR TITLE
Corrigindo renderizações dos colaboradores

### DIFF
--- a/src/components/Dev/index.jsx
+++ b/src/components/Dev/index.jsx
@@ -1,7 +1,7 @@
 import { styled } from "../../../stitches.config";
 import style from "./style.css"
 
-export function Dev(name, image, office, desc) {
+export function Dev({ name, image, office, desc }) {
   return (
     <Devs>
       <img src={image} alt={name} />

--- a/src/components/Group/index.jsx
+++ b/src/components/Group/index.jsx
@@ -10,7 +10,14 @@ export function Group(props) {
       }}
     >
       <TitleCard>{props.name}</TitleCard>
-      <Dev></Dev>
+      {props.colaborators.map((colaborator) => (
+        <Dev
+          key={colaborator.name}
+          {...colaborator}
+          primaryColor={props.primaryColor}
+          secondColor={props.secondColor}
+        />
+      ))}
     </Section>
   );
 }

--- a/src/components/ListTimes/index.jsx
+++ b/src/components/ListTimes/index.jsx
@@ -12,16 +12,8 @@ export function ListTimes(props) {
           name={time.name}
           primaryColor={time.primaryColor}
           secondColor={time.secondColor}
-        >
-          {props.colaborators.map((colaborator) => (
-            <Dev
-              name={colaborator.name}
-              office={colaborator.office}
-              desc={colaborator.desc}
-              image={colaborator.image}
-            ></Dev>
-          ))}
-        </Group>
+          colaborators={props.colaborators.filter((colaborator) => colaborator.group === time.name)}
+        />
       ))}
     </main>
   );


### PR DESCRIPTION
Alterei para não ficar renderizando o mesmo colaborador em todos os times, mesmo que esteja definido para estar em um único time. 

Fiz da seguinte forma: passei a responsabilidade de renderizar os colaboradores por componente Group e passei para ele através de props os colaboradores que são dele com uso do método filter no array de colaboradores.

Além disso, corrigi a parte da desestruturação das props no componente Dev.

Qualquer dúvida, só mandar!